### PR TITLE
Fix creche overlay background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,7 +1433,7 @@ window.__vite_plugin_react_preamble_installed__ = true
             }, 10);
             
             // Exemple de contenu dynamique (à remplacer par du contenu réel)
-            ficheZoom.className = "fixed top-[5%] left-[5%] w-[90%] h-[90%] bg-white/95 backdrop-blur-md rounded-2xl shadow-2xl p-10 z-50 transition-all duration-500 ease-in-out opacity-0 scale-95 pointer-events-none transform-gpu";
+              ficheZoom.className = `fixed top-[5%] left-[5%] w-[90%] h-[90%] ${creche.ficheBg || 'bg-white/95'} backdrop-blur-md rounded-2xl shadow-2xl p-10 z-50 transition-all duration-500 ease-in-out opacity-0 scale-95 pointer-events-none transform-gpu`;
             ficheZoom.style.backgroundImage = '';
             ficheZoom.style.backgroundSize = '';
             ficheZoom.style.backgroundPosition = '';
@@ -1901,7 +1901,7 @@ window.__vite_plugin_react_preamble_installed__ = true
           crechesCardGroup.innerHTML = ''; // Vider le contenu existant
           crechesData.forEach(creche => {
             const cardDiv = document.createElement('div');
-            cardDiv.className = `card flex-1 ${creche.couleurBg.replace('bg-', 'bg-') || 'bg-gray-300'} rounded-xl shadow-lg flex items-center justify-center cursor-pointer hover:shadow-xl transition-all duration-500 p-4 text-center overflow-hidden transform hover:scale-110 hover:-translate-y-2 hover:z-10 relative`;
+            cardDiv.className = `card flex-1 ${creche.couleurBg || 'bg-gray-300'} rounded-xl shadow-lg flex items-center justify-center cursor-pointer hover:shadow-xl transition-all duration-500 p-4 text-center overflow-hidden transform hover:scale-110 hover:-translate-y-2 hover:z-10 relative`;
             cardDiv.setAttribute('onclick', `handleOpenDetailView('${creche.id}', '${creche.couleurBg}')`);
             
             cardDiv.innerHTML = `


### PR DESCRIPTION
## Summary
- use creche `ficheBg` gradient when displaying the detail view
- simplify card background class

## Testing
- `node -e "try {new Function(require('fs').readFileSync('README.md','utf8'));console.log('OK');}catch(e){console.error(e.message);}"`

------
https://chatgpt.com/codex/tasks/task_e_6842c0858c3c8329b0b14e1e09cb4d5d